### PR TITLE
Read files in input directories according to file extensions

### DIFF
--- a/mlstream/datasets.py
+++ b/mlstream/datasets.py
@@ -43,8 +43,6 @@ class LumpedBasin(Dataset):
         input data, by default True
     db_path : str, optional
         Path to sqlite3 database file containing the catchment characteristics, by default None
-    forcings_file_format : str, optional
-        File format for lumped forcings files
     allow_negative_target : bool, optional
         If False, will remove samples with negative target value from the dataset.
     scalers : Tuple[InputScaler, OutputScaler, Dict[str, StaticAttributeScaler]], optional
@@ -64,7 +62,6 @@ class LumpedBasin(Dataset):
                  with_attributes: bool = False,
                  concat_static: bool = True,
                  db_path: str = None,
-                 forcings_file_format: str = 'rvt',
                  allow_negative_target: bool = False,
                  scalers: Tuple[InputScaler, OutputScaler,
                                 Dict[str, StaticAttributeScaler]] = None):
@@ -78,7 +75,6 @@ class LumpedBasin(Dataset):
         self.with_attributes = with_attributes
         self.concat_static = concat_static
         self.db_path = db_path
-        self.forcings_file_format = forcings_file_format
         self.allow_negative_target = allow_negative_target
         if scalers is not None:
             self.input_scalers, self.output_scalers, self.static_scalers = scalers
@@ -87,8 +83,7 @@ class LumpedBasin(Dataset):
         if self.input_scalers is None:
             self.input_scalers = InputScaler(self.data_root, self.train_basins,
                                              self.dates[0], self.dates[1],
-                                             self.forcing_vars,
-                                             self.forcings_file_format)
+                                             self.forcing_vars)
         if self.output_scalers is None:
             self.output_scalers = OutputScaler(self.data_root, self.train_basins,
                                                self.dates[0], self.dates[1])
@@ -125,7 +120,7 @@ class LumpedBasin(Dataset):
         """Loads input and output data from text files. """
         # we use (seq_len) time steps before start for warmup
 
-        df = load_forcings_lumped(self.data_root, [self.basin], self.forcings_file_format)[self.basin]
+        df = load_forcings_lumped(self.data_root, [self.basin])[self.basin]
         qobs = load_discharge(self.data_root, basins=[self.basin]).set_index('date')['qobs']
         if not self.is_train and len(qobs) == 0:
             tqdm.write(f"Treating {self.basin} as validation basin (no streamflow data found).")

--- a/mlstream/datautils.py
+++ b/mlstream/datautils.py
@@ -64,7 +64,7 @@ def load_discharge(data_root: Path, basins: List = None) -> pd.DataFrame:
         A DataFrame with columns [date, basin, qobs], where 'qobs' contains the streamflow.
     """
     discharge_dir = data_root / 'discharge'
-    files = discharge_dir.glob('*')
+    files = [f for f in discharge_dir.glob('*') if f.is_file()]
 
     data_streamflow = pd.DataFrame(columns=['date', 'basin', 'qobs'])
     found_basins = []
@@ -117,7 +117,7 @@ def load_forcings_lumped(data_root: Path, basins: List = None) -> Dict:
         Dictionary of forcings (pd.DataFrame) per basin
     """
     lumped_dir = data_root / 'forcings' / 'lumped'
-    basin_files = lumped_dir.glob('*')
+    basin_files = [f for f in lumped_dir.glob('*') if f.is_file()]
 
     basin_forcings = {}
     for f in basin_files:

--- a/mlstream/datautils.py
+++ b/mlstream/datautils.py
@@ -47,7 +47,7 @@ def get_basin_list(data_root: Path, basin_type: str) -> List:
     return np.unique(basins).tolist()
 
 
-def load_discharge(data_root: Path, basins: List = None, file_format: str = 'nc') -> pd.DataFrame:
+def load_discharge(data_root: Path, basins: List = None) -> pd.DataFrame:
     """Loads observed discharge for (calibration) gauging stations.
 
     Parameters
@@ -57,48 +57,50 @@ def load_discharge(data_root: Path, basins: List = None, file_format: str = 'nc'
         with one or more nc-files.
     basins : List, optional
         List of basins for which to return data. If None (default), all basins are returned
-    file_format : str, optional
-        Format of the discharge files. Default, and currently only supported format is 'nc'.
 
     Returns
     -------
     pd.DataFrame
         A DataFrame with columns [date, basin, qobs], where 'qobs' contains the streamflow.
     """
-    if file_format != 'nc':
-        raise NotImplementedError(f"Discharge format {file_format} not supported.")
-
     discharge_dir = data_root / 'discharge'
-    files = discharge_dir.glob('*.nc')
+    files = discharge_dir.glob('*')
 
     data_streamflow = pd.DataFrame(columns=['date', 'basin', 'qobs'])
     found_basins = []
     for f in files:
-        q_nc = nc.Dataset(f, 'r')
-        file_basins = np.array([f.zfill(8) for f in q_nc['station_id'][:]])
-        if basins is not None:
-            # some basins might be in multiple NC-files. We only load them once.
-            target_basins = [i for i, b in enumerate(file_basins)
-                             if b in basins and b not in found_basins]
-        else:
-            target_basins = [i for i, b in enumerate(file_basins)
-                             if b not in found_basins]
-        if len(target_basins) > 0:
-            time = nc.num2date(q_nc['time'][:], q_nc['time'].units, q_nc['time'].calendar)
-            data = pd.DataFrame(q_nc['Q'][target_basins, :].T, index=time,
-                                columns=file_basins[target_basins])
-            data = data.unstack().reset_index().rename({'level_0': 'basin',
-                                                        'level_1': 'date',
-                                                        0: 'qobs'}, axis=1)
-            found_basins += data['basin'].unique().tolist()
-            data_streamflow = data_streamflow.append(data, ignore_index=True, sort=True)
+        try:
+            file_format = f.name.split(".")[-1]
+            if file_format == "nc":
+                q_nc = nc.Dataset(f, 'r')
+                file_basins = np.array([f.zfill(8) for f in q_nc['station_id'][:]])
+                if basins is not None:
+                    # some basins might be in multiple NC-files. We only load them once.
+                    target_basins = [i for i, b in enumerate(file_basins)
+                                     if b in basins and b not in found_basins]
+                else:
+                    target_basins = [i for i, b in enumerate(file_basins)
+                                     if b not in found_basins]
+                if len(target_basins) > 0:
+                    time = nc.num2date(q_nc['time'][:], q_nc['time'].units, q_nc['time'].calendar)
+                    data = pd.DataFrame(q_nc['Q'][target_basins, :].T, index=time,
+                                        columns=file_basins[target_basins])
+                    data = data.unstack().reset_index().rename({'level_0': 'basin',
+                                                                'level_1': 'date',
+                                                                0: 'qobs'}, axis=1)
+                    found_basins += data['basin'].unique().tolist()
+                    data_streamflow = data_streamflow.append(data, ignore_index=True, sort=True)
 
-        q_nc.close()
+                q_nc.close()
+            else:
+                raise NotImplementedError(f"Discharge format {file_format} not supported.")
+        except Exception as e:
+            print (f"Couldn't load discharge from {f.name}. Skipping ...")
 
     return data_streamflow
 
 
-def load_forcings_lumped(data_root: Path, basins: List = None, file_format: str = 'rvt') -> Dict:
+def load_forcings_lumped(data_root: Path, basins: List = None) -> Dict:
     """Loads basin-lumped forcings.
 
     Parameters
@@ -108,43 +110,40 @@ def load_forcings_lumped(data_root: Path, basins: List = None, file_format: str 
         which contains one .rvt/.csv/.txt -file per basin.
     basins : List, optional
         List of basins for which to return data. Default (None) returns data for all basins.
-    file_format : str, optional
-        Format of the forcing files. Default format is 'rvt' but 'csv' is also supported.
-        - rvt format: fourth line contains column names (",\s+"-sepatated), following lines contain ",\s*"-separated
-            data. Second line starts with start date (yyyy-mm-dd). Last line is footer.
-        - txt/csv format: first line is header, following lines are comma-separated. First column contains dates
-            as yyyy-mm-dd.
 
     Returns
     -------
     dict
         Dictionary of forcings (pd.DataFrame) per basin
     """
-    if file_format not in ['rvt', 'csv', 'txt']:
-        raise NotImplementedError(f"Forcing format {file_format} not supported.")
-
     lumped_dir = data_root / 'forcings' / 'lumped'
-    basin_files = lumped_dir.glob('*.' + file_format)
+    basin_files = lumped_dir.glob('*')
 
     basin_forcings = {}
     for f in basin_files:
-        basin = f.name.split('_')[-1][:-4].zfill(8)
-        if basins is not None and basin not in basins:
-            continue
-        if file_format == 'rvt':
-            with open(f) as fp:
-                next(fp)
-                start_date = next(fp)[:10]
-                columns = re.split(r',\s+', next(fp).replace('\n', ''))[1:]
-            data = pd.read_csv(f, sep=r',\s*', skiprows=4, skipfooter=1, names=columns, dtype=float,
-                               header=None, usecols=range(len(columns)), engine='python')
-        elif file_format in ['txt', 'csv']:
-            with open(f) as fp:
-                columns = re.split(',', next(fp).replace('\n', ''))[1:]
-                start_date = next(fp)[:10]
-            data = pd.read_csv(f, dtype=float, usecols=range(1, len(columns)+1))
-        data.index = pd.date_range(start_date, periods=len(data), freq='D')
-        basin_forcings[basin] = data
+        try:
+            basin = f.name.split('_')[-1][:-4].zfill(8)
+            file_format = f.name.split(".")[-1]
+            if basins is not None and basin not in basins:
+                continue
+            if file_format == 'rvt':
+                with open(f) as fp:
+                    next(fp)
+                    start_date = next(fp)[:10]
+                    columns = re.split(r',\s+', next(fp).replace('\n', ''))[1:]
+                data = pd.read_csv(f, sep=r',\s*', skiprows=4, skipfooter=1, names=columns, dtype=float,
+                                   header=None, usecols=range(len(columns)), engine='python')
+            elif file_format in ['txt', 'csv']:
+                with open(f) as fp:
+                    columns = re.split(',', next(fp).replace('\n', ''))[1:]
+                    start_date = next(fp)[:10]
+                data = pd.read_csv(f, dtype=float, usecols=range(1, len(columns)+1))
+            else:
+                raise NotImplementedError(f"Forcing format {file_format} not supported.")
+            data.index = pd.date_range(start_date, periods=len(data), freq='D')
+            basin_forcings[basin] = data
+        except Exception as e:
+            print (f"Couldn't load lumped forcings from {f.name}. Skipping ...")
 
     return basin_forcings
 

--- a/mlstream/experiment.py
+++ b/mlstream/experiment.py
@@ -23,7 +23,6 @@ class Experiment:
                  concat_static: bool = False, no_static: bool = False,
                  cache_data: bool = False, n_jobs: int = 1, seed: int = 0,
                  allow_negative_target: bool = False,
-                 forcings_file_format: str = 'rvt',
                  run_metadata: Dict = {}):
         """Initializes the experiment.
 
@@ -64,8 +63,6 @@ class Experiment:
             If False, will ignore training samples with negative target value from the dataset, and will
             clip predictions to values >= 0. This value should be False when predicting discharge, but True
             when predicting values that can be negative.
-        forcings_file_format : str, optional
-            File format for lumped forcing files. Can be 'csv' or 'rvt' or 'txt'
         run_metadata : dict, optional
             Optional dictionary of values to store in cfg.json for documentation purpose.
         """
@@ -86,7 +83,6 @@ class Experiment:
             "no_static": no_static,
             "seed": seed,
             "n_jobs": n_jobs,
-            "forcings_file_format": forcings_file_format,
             "allow_negative_target": allow_negative_target
         }
         self.cfg.update(run_metadata)
@@ -147,8 +143,7 @@ class Experiment:
         # create scalers
         input_scalers = InputScaler(self.cfg["data_root"], run_cfg["basins"],
                                     run_cfg["start_date"], run_cfg["end_date"],
-                                    run_cfg["forcing_attributes"],
-                                    run_cfg["forcings_file_format"])
+                                    run_cfg["forcing_attributes"])
         output_scalers = OutputScaler(self.cfg["data_root"], run_cfg["basins"],
                                       run_cfg["start_date"], run_cfg["end_date"])
         static_scalers = {}
@@ -171,7 +166,6 @@ class Experiment:
                                   concat_static=run_cfg["concat_static"],
                                   db_path=db_path,
                                   allow_negative_target=run_cfg["allow_negative_target"],
-                                  forcings_file_format=run_cfg["forcings_file_format"],
                                   scalers=(input_scalers, output_scalers, static_scalers))
 
             preds, obs = self.predict_basin(ds_test, allow_negative_target=run_cfg["allow_negative_target"])

--- a/mlstream/scaling.py
+++ b/mlstream/scaling.py
@@ -25,13 +25,12 @@ class InputScaler(Scaler):
 
     def __init__(self, data_root: Path, basins: List,
                  start_date: pd.Timestamp, end_date: pd.Timestamp,
-                 forcing_vars: List = None,
-                 forcings_file_format: str = 'rvt'):
+                 forcing_vars: List = None):
         super().__init__()
 
         all_forcings = pd.DataFrame()
         print("Loading forcings for input scaler.")
-        basin_forcings = load_forcings_lumped(data_root, basins, forcings_file_format)
+        basin_forcings = load_forcings_lumped(data_root, basins)
         for basin, forcing in basin_forcings.items():
             if forcing_vars is not None:
                 all_forcings = all_forcings.append(forcing.loc[start_date:end_date, forcing_vars])

--- a/mlstream/utils.py
+++ b/mlstream/utils.py
@@ -21,8 +21,7 @@ def create_h5_files(data_root: Path,
                     dates: List,
                     forcing_vars: List,
                     seq_length: int,
-                    allow_negative_target: bool,
-                    forcings_file_format: str):
+                    allow_negative_target: bool):
     """Creates H5 training set.
 
     Parameters
@@ -41,8 +40,6 @@ def create_h5_files(data_root: Path,
         Length of the requested input sequences
     allow_negative_target : bool, optional
         If False, will remove samples with negative target value from the dataset.
-    forcings_file_format : str
-        File format of lumped forcings file
 
     Raises
     ------
@@ -90,7 +87,6 @@ def create_h5_files(data_root: Path,
                                   seq_length=seq_length,
                                   dates=dates,
                                   scalers=scalers,
-                                  forcings_file_format=forcings_file_format,
                                   allow_negative_target=allow_negative_target,
                                   with_attributes=False)
             if len(dataset) == 0:
@@ -175,8 +171,7 @@ def prepare_data(cfg: Dict, basins: List) -> Dict:
                     dates=[cfg["start_date"], cfg["end_date"]],
                     forcing_vars=cfg["forcing_attributes"],
                     seq_length=cfg["seq_length"],
-                    allow_negative_target=cfg["allow_negative_target"],
-                    forcings_file_format=cfg["forcings_file_format"])
+                    allow_negative_target=cfg["allow_negative_target"])
 
     return cfg
 


### PR DESCRIPTION
Removed the `file_format` parameters. Forcings and discharge files are read as per the extension and files with unsupported extension or incorrect structure are skipped.